### PR TITLE
VDC: increase the fixed HSW to 3 (1941)

### DIFF
--- a/rtl/main.sv
+++ b/rtl/main.sv
@@ -235,7 +235,6 @@ module pce (
 
       .ReducedVBL(~overscan_enable),
       .BORDER_EN(0),
-      .DOTCLOCK_DIVIDER(dotclock_divider),
       .VIDEO_R(r),
       .VIDEO_G(g),
       .VIDEO_B(b),

--- a/rtl/pce/huc6260.vhd
+++ b/rtl/pce/huc6260.vhd
@@ -246,12 +246,12 @@ begin
 	end if;
 end process;
 
-HSYNC_START_POS <= 64-1 when DOTCLOCK = "00" else 
-                72-1 when DOTCLOCK = "01" else 
-                LINE_CLOCKS-1;
-HSYNC_END_POS <= 64+464-1 when DOTCLOCK = "00" else 
-              72+468-1 when DOTCLOCK = "01" else 
-              468-1;
+HSYNC_START_POS <= 32-1 when DOTCLOCK = "00" else 
+                   66-1 when DOTCLOCK = "01" else 
+                   LINE_CLOCKS-1;
+HSYNC_END_POS   <= 32+464-1 when DOTCLOCK = "00" else 
+                   66+468-1 when DOTCLOCK = "01" else 
+                   468-1;
 process( CLK )
 begin
 	if rising_edge( CLK ) then

--- a/rtl/pce/huc6270.vhd
+++ b/rtl/pce/huc6270.vhd
@@ -320,7 +320,7 @@ begin
 					DOTS_REMAIN <= DOT_CNT;
 					
 					if HSYNC_F = '1' then
-						HSW <= "00010";
+						HSW <= "00011";
 					else 
 						HSW <= HSR_HSW;
 					end if; 


### PR DESCRIPTION
Brings fix for "1941" from upstream MiSTer core.
Also, removes `.DOTCLOCK_DIVIDER` from `main.sv` since that's unused and prevents compilation.